### PR TITLE
Return the current URL when casting FluentUrlBuilder to string

### DIFF
--- a/src/FluentUrlBuilder.php
+++ b/src/FluentUrlBuilder.php
@@ -210,4 +210,8 @@ class FluentUrlBuilder
         return $this->buildParams;
     }
 
+    public function __toString()
+    {
+        return $this->url();
+    }
 }

--- a/tests/Unit/FluentUrlTest.php
+++ b/tests/Unit/FluentUrlTest.php
@@ -96,4 +96,11 @@ class FluentUrlTest extends TestCase
         $this->assertNotFalse(strpos($urlParsed['path'],'bar'));
 
     }
+
+    public function testStringCast()
+    {
+        $this->glideUrl->setPath('foo');
+
+        $this->assertEquals('/img/foo?s=7af3bd98ffed0ef0d402c2d33bd88b43', (string)$this->glideUrl);
+    }
 }


### PR DESCRIPTION
This removes the requirement to call FluentUrlBuilder::url() to obtain the
image URL.

For example, it is now possible to do the following:

```php
// $urlBuilder is an instance of FluentUrlBuilder

print $urlBuilder->setPath('image_filename')->width(250)->jpeg(); // obtain a JPEG

print $urlBuilder->setPath('image_filename')->width(250)->png(); // obtain a PNG
```

Previously, this would have been necessary:

```php
// $urlBuilder is an instance of FluentUrlBuilder

print $urlBuilder->setPath('image_filename')->width(250)->jpeg()->url(); // obtain a JPEG

print $urlBuilder->setPath('image_filename')->width(250)->png()->url(); // obtain a PNG
```

This update maintains the original behaviour so there is no BC break.