### PR TITLE
Add avif format and FluentUrlBuilder cloning support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relevant Glide parameter is removed as appropriate
 - Filters can be cleared by calling `filt()` with no arguments
 - Flip can be cleared by calling `flip()` with no arguments
+- Orientation can be cleared by calling `orientation()` with no arguments
 
 ### Fixed
 - Setting an encoding option without an explicit quality value clears the quality parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filters can be cleared by calling `filt()` with no arguments
 - Flip can be cleared by calling `flip()` with no arguments
 - Orientation can be cleared by calling `orientation()` with no arguments
+- Most watermark parameters can be cleared:
+  - `mark()`
+  - `markWidth()`
+  - `markHeight()`
+  - `markX()`
+  - `markY()`
+  - `markPad()`
 
 ### Fixed
 - Setting an encoding option without an explicit quality value clears the quality parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `markX()`
   - `markY()`
   - `markPad()`
+- Glide FluentUrlBuilder instances can now be cloned using the `FluentUrlBuilder::clone()`
 
 ### Fixed
 - Setting an encoding option without an explicit quality value clears the quality parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Height and width parameter can be cleared by calling `height()` or `width()` with no argument.
+  This also applies to `size()` - both `width` and `height` arguments are optional and the 
+  relevant Glide parameter is removed as appropriate
+
 ### Fixed
 - Setting an encoding option without an explicit quality value clears the quality parameter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Setting an encoding option without an explicit quality value clears the quality parameter
+
 ## [0.3.0] - 2022-03-14
 
 ###Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Height and width parameter can be cleared by calling `height()` or `width()` with no argument.
   This also applies to `size()` - both `width` and `height` arguments are optional and the 
   relevant Glide parameter is removed as appropriate
+- Filters can be cleared by calling `filt()` with no arguments
 
 ### Fixed
 - Setting an encoding option without an explicit quality value clears the quality parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `markY()`
   - `markPad()`
 - Glide FluentUrlBuilder instances can now be cloned using the `FluentUrlBuilder::clone()`
+- Avif support via `FluentUrlBuilder::avif()`
 
 ### Fixed
 - Setting an encoding option without an explicit quality value clears the quality parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This also applies to `size()` - both `width` and `height` arguments are optional and the 
   relevant Glide parameter is removed as appropriate
 - Filters can be cleared by calling `filt()` with no arguments
+- Flip can be cleared by calling `flip()` with no arguments
 
 ### Fixed
 - Setting an encoding option without an explicit quality value clears the quality parameter

--- a/src/Can/HasEffects.php
+++ b/src/Can/HasEffects.php
@@ -68,7 +68,9 @@ trait HasEffects
     /**
      * Applies a filter effect to the image.  Accepts greyscale or sepia.
      *
-     * @param string $filter Filter to apply.  Acceptable values are:
+     * Filter is removed if `null` is passed.
+     *
+     * @param string|null $filter Filter to apply.  Acceptable values are:
      *                       - 'greyscale',
      *                       - 'sepia'.
      *
@@ -79,14 +81,20 @@ trait HasEffects
      * @return HasEffects
      * @throws InvalidFilterException
      */
-    public function filt(string $filter)
+    public function filt(string $filter = null)
     {
         if ($filter !== Filter::GREYSCALE &&
-            $filter !== Filter::SEPIA) {
+            $filter !== Filter::SEPIA &&
+            $filter !== null
+        ) {
             throw new InvalidFilterException();
         }
 
         $this->buildParams['filt'] = $filter;
+
+        if ($filter === null) {
+            unset($this->buildParams['filt']);
+        }
 
         return $this;
     }
@@ -94,7 +102,9 @@ trait HasEffects
     /**
      * Applies a filter effect to the image.  Accepts greyscale or sepia.
      *
-     * @param string $filter Filter to apply.  Acceptable values are:
+     * Filter is removed if `null` is passed.
+     *
+     * @param string|null $filter Filter to apply.  Acceptable values are:
      *                       - 'greyscale',
      *                       - 'sepia'.
      *
@@ -106,7 +116,7 @@ trait HasEffects
      * @throws InvalidFilterException
      * @see HasEffects::filt()
      */
-    public function filter(string $filter)
+    public function filter(string $filter = null)
     {
         return $this->filt($filter);
     }

--- a/src/Can/HasEncode.php
+++ b/src/Can/HasEncode.php
@@ -90,6 +90,8 @@ trait HasEncode
      */
     public function quality(int $quality = null)
     {
+        unset($this->buildParams['q']);
+
         if ($quality !== null) {
             $this->buildParams['q'] = $quality;
         }

--- a/src/Can/HasEncode.php
+++ b/src/Can/HasEncode.php
@@ -17,6 +17,19 @@ use AmpedWeb\GlideUrl\FluentUrlBuilder;
 trait HasEncode
 {
     /**
+     * Encode the image to AVIF
+     *
+     * @param int|null $quality
+     *
+     * @return FluentUrlBuilder
+     */
+    public function avif(int $quality = null)
+    {
+        $this->buildParams['fm'] = 'avif';
+        return $this->quality($quality);
+    }
+
+    /**
      * Encode the image to GIF
      *
      * @param int|null $quality

--- a/src/Can/HasFlip.php
+++ b/src/Can/HasFlip.php
@@ -19,10 +19,13 @@ trait HasFlip
     /**
      * Flip the image
      *
-     * @param string $flip One of:
+     * If $flip is `null`, the flip parameter is removed
+     *
+     * @param string|null $flip One of:
      *                     - 'both',
      *                     - 'h',
      *                     - 'v'.
+     *                     - null
      *                     Or you can use the interface constants:
      *                     - Flip::BOTH
      *                     - FLip::HORIZONTAL
@@ -31,16 +34,21 @@ trait HasFlip
      * @return $this
      * @throws InvalidFlipException
      */
-    public function flip(string $flip)
+    public function flip(string $flip = null)
     {
         if ($flip !== Flip::BOTH &&
             $flip !== Flip::HORIZONTAL &&
-            $flip !== Flip::VERTICAL
+            $flip !== Flip::VERTICAL &&
+            $flip !== null
         ) {
             throw new InvalidFlipException();
         }
 
         $this->buildParams['flip'] = $flip;
+
+        if ($flip === null) {
+            unset($this->buildParams['flip']);
+        }
 
         return $this;
     }

--- a/src/Can/HasOrientation.php
+++ b/src/Can/HasOrientation.php
@@ -27,7 +27,9 @@ trait HasOrientation
      *
      * The `auto` option uses Exif data to decide on orientation.
      *
-     * @param string $orientation One of:
+     * If $orientation is not passed, or `null` is passed, the orientation Glide parameter is removed
+     *
+     * @param string|null $orientation One of:
      *                            - 'auto'
      *                            - '0'
      *                            - '90'
@@ -43,18 +45,23 @@ trait HasOrientation
      * @return $this
      * @throws InvalidOrientationException
      */
-    public function orientation(string $orientation)
+    public function orientation(string $orientation = null)
     {
         if ($orientation !== Rotate::AUTO &&
             $orientation !== Rotate::R0 &&
             $orientation !== Rotate::R90 &&
             $orientation !== Rotate::R180 &&
-            $orientation !== Rotate::R270
+            $orientation !== Rotate::R270 &&
+            $orientation !== null
         ) {
             throw new InvalidOrientationException();
         }
 
         $this->buildParams['or'] = $orientation;
+
+        if ($orientation === null) {
+            unset($this->buildParams['or']);
+        }
 
         return $this;
     }

--- a/src/Can/HasSize.php
+++ b/src/Can/HasSize.php
@@ -4,7 +4,6 @@
 namespace AmpedWeb\GlideUrl\Can;
 
 use AmpedWeb\GlideUrl\Exceptions\InvalidFitException;
-use AmpedWeb\GlideUrl\Exceptions\InvalidSizeFitException;
 use AmpedWeb\GlideUrl\Interfaces\Fit;
 
 /**
@@ -56,13 +55,19 @@ trait HasSize
     /**
      * Sets the width of the image, in pixels.
      *
-     * @param int $width
+     * If null, clear the width parameter.
+     *
+     * @param int|null $width
      *
      * @return $this
      */
-    public function width(int $width)
+    public function width(int $width = null)
     {
         $this->buildParams['w'] = $width;
+
+        if ($width === null) {
+            unset($this->buildParams['w']);
+        }
 
         return $this;
     }
@@ -70,13 +75,19 @@ trait HasSize
     /**
      * Sets the height of the image, in pixels.
      *
-     * @param int $height
+     * If null, clear the height parameter.
+     *
+     * @param int|null $height
      *
      * @return $this
      */
-    public function height(int $height)
+    public function height(int $height = null)
     {
         $this->buildParams['h'] = $height;
+
+        if ($height === null) {
+            unset($this->buildParams['h']);
+        }
 
         return $this;
     }
@@ -84,12 +95,15 @@ trait HasSize
     /**
      * Sets the width and height of the image, in pixels.
      *
-     * @param int $width
-     * @param int $height
+     * If $width is not passed, the width Glide parameter is removed and the height parameter is set
+     * If $height is not passed, the height Glide parameter is removed and the width parameter is set
+     *
+     * @param int|null $width
+     * @param int|null $height
      *
      * @return HasSize|\AmpedWeb\GlideUrl\FluentUrlBuilder
      */
-    public function size(int $width, int $height)
+    public function size(int $width = null, int $height = null)
     {
         return $this->width($width)->height($height);
     }

--- a/src/Can/HasWatermarks.php
+++ b/src/Can/HasWatermarks.php
@@ -56,13 +56,19 @@ trait HasWatermarks
      *
      * Must be a path to an image in the watermarks file system, as configured in your server.
      *
-     * @param string $filename
+     * If $filename is null, the watermark parameter is removed
+     *
+     * @param string|null $filename
      *
      * @return HasWatermarks
      */
-    public function mark(string $filename)
+    public function mark(string $filename = null)
     {
         $this->buildParams['mark'] = $filename;
+
+        if ($filename === null) {
+            unset($this->buildParams['mark']);
+        }
 
         return $this;
     }
@@ -70,13 +76,20 @@ trait HasWatermarks
     /**
      * Sets the width of the watermark in pixels, or using relative dimensions.
      *
-     * @param string $dimension
+     * If $dimension is null, the watermark width parameter is removed
+     *
+     * @param string|null $dimension
      *
      * @return HasWatermarks
      * @throws InvalidDimensionException
      */
-    public function markWidth(string $dimension)
+    public function markWidth(string $dimension = null)
     {
+        if ($dimension === null) {
+            unset($this->buildParams['markw']);
+            return $this;
+        }
+
         $this->buildParams['markw'] = $this->parseDimension($dimension);
 
         return $this;
@@ -85,13 +98,20 @@ trait HasWatermarks
     /**
      * Sets the height of the watermark in pixels, or using relative dimensions.
      *
-     * @param string $dimension
+     * If $dimension is null, the height parameter is removed
+     *
+     * @param string|null $dimension
      *
      * @return HasWatermarks
      * @throws InvalidDimensionException
      */
-    public function markHeight(string $dimension)
+    public function markHeight(string $dimension = null)
     {
+        if ($dimension === null) {
+            unset($this->buildParams['markh']);
+            return $this;
+        }
+
         $this->buildParams['markh'] = $this->parseDimension($dimension);
 
         return $this;
@@ -155,13 +175,20 @@ trait HasWatermarks
      *
      * Set in pixels, or using relative dimensions. Ignored if `markpos` is set to center.
      *
-     * @param string $dimension
+     * If $dimension is null, the parameter is removed
+     *
+     * @param string|null $dimension
      *
      * @return HasWatermarks
      * @throws InvalidDimensionException
      */
-    public function markX(string $dimension)
+    public function markX(string $dimension = null)
     {
+        if ($dimension === null) {
+            unset ($this->buildParams['markx']);
+            return $this;
+        }
+
         $this->buildParams['markx'] = $this->parseDimension($dimension);
 
         return $this;
@@ -172,13 +199,20 @@ trait HasWatermarks
      *
      * Set in pixels, or using relative dimensions. Ignored if `markpos` is set to center.
      *
-     * @param string $dimension
+     * If $dimension is null, the parameter is removed.
+     *
+     * @param string|null $dimension
      *
      * @return HasWatermarks
      * @throws InvalidDimensionException
      */
-    public function markY(string $dimension)
+    public function markY(string $dimension = null)
     {
+        if ($dimension === null) {
+            unset($this->buildParams['marky']);
+            return $this;
+        }
+
         $this->buildParams['marky'] = $this->parseDimension($dimension);
 
         return $this;
@@ -190,12 +224,20 @@ trait HasWatermarks
      * Basically a shortcut for using both `markx` and `marky`. Set in pixels, or using relative dimensions. Ignored if
      * `markpos` is set to center.
      *
-     * @param string $dimension
+     * If $dimension is null, the parameter is removed.
+     *
+     * @param string|null $dimension
      *
      * @return HasWatermarks
+     * @throws InvalidDimensionException
      */
-    public function markPad(string $dimension)
+    public function markPad(string $dimension = null)
     {
+        if ($dimension === null) {
+            unset ($this->buildParams['markpad']);
+            return $this;
+        }
+
         $this->buildParams['markpad'] = $this->parseDimension($dimension);
 
         return $this;

--- a/src/FluentUrlBuilder.php
+++ b/src/FluentUrlBuilder.php
@@ -191,6 +191,16 @@ class FluentUrlBuilder
     }
 
     /**
+     * Create a clone of the current URL Builder
+     *
+     * @return FluentUrlBuilder
+     */
+    public function clone(): FluentUrlBuilder
+    {
+        return clone($this);
+    }
+
+    /**
      * Get the URL to your image after building the configuration
      *
      * @return string

--- a/tests/Unit/EffectsTest.php
+++ b/tests/Unit/EffectsTest.php
@@ -25,6 +25,13 @@ class EffectsTest extends TestCase
         $this->assertSame($this->glideUrl, $this->glideUrl->filt('greyscale'));
     }
 
+    public function testFiltCanBeRemoved()
+    {
+        $this->glideUrl->filt(Filter::GREYSCALE)->filt();
+
+        $this->assertArrayNotHasKey('filt', $this->glideUrl->getParams());
+    }
+
     public function testBlurSetsCorrectValues()
     {
         $this->glideUrl->blur(45);

--- a/tests/Unit/EncodeTest.php
+++ b/tests/Unit/EncodeTest.php
@@ -47,6 +47,15 @@ class EncodeTest extends TestCase
         $this->assertEquals(50, $this->glideUrl->getParams()['q']);
     }
 
+    public function testQualityIsClearedWhenNotExplicitlyPassed()
+    {
+        $this->glideUrl->jpeg(50);
+        $this->assertEquals(50, $this->glideUrl->getParams()['q']);
+
+        $this->glideUrl->jpeg();
+        $this->assertArrayNotHasKey('q', $this->glideUrl->getParams());
+    }
+
 //    public function testGif()
 //    {
 //        $response = $this->get(glide_url('cat.png')->build()->gif()->url());

--- a/tests/Unit/EncodeTest.php
+++ b/tests/Unit/EncodeTest.php
@@ -47,6 +47,13 @@ class EncodeTest extends TestCase
         $this->assertEquals(50, $this->glideUrl->getParams()['q']);
     }
 
+    public function testAvifSetsCorrectValue()
+    {
+        $this->glideUrl->avif(50);
+        $this->assertEquals('avif', $this->glideUrl->getParams()['fm']);
+        $this->assertEquals(50, $this->glideUrl->getParams()['q']);
+    }
+
     public function testQualityIsClearedWhenNotExplicitlyPassed()
     {
         $this->glideUrl->jpeg(50);

--- a/tests/Unit/FlipTest.php
+++ b/tests/Unit/FlipTest.php
@@ -34,4 +34,10 @@ class FlipTest extends TestCase
         $this->glideUrl->flip(Flip::BOTH);
         $this->assertEquals('both', $this->glideUrl->getParams()['flip']);
     }
+
+    public function testFlipCanBeCleared()
+    {
+        $this->glideUrl->flip(Flip::BOTH)->flip();
+        $this->assertArrayNotHasKey('flip', $this->glideUrl->getParams());
+    }
 }

--- a/tests/Unit/FluentUrlTest.php
+++ b/tests/Unit/FluentUrlTest.php
@@ -227,4 +227,18 @@ class FluentUrlTest extends TestCase
         $foo->markHeight(20)->markHeight(50);
         $this->assertEquals(50, $foo->getParams()['markh']);
     }
+
+    public function testCloningAGlideUrl()
+    {
+        $foo = $this->glideUrl->setPath('foo')->width(45)->fit(Fit::CONTAIN)->jpeg();
+        $bar = $foo->clone()->png()->width(120);
+
+        $this->assertNotEmpty($bar, $foo);
+
+        $this->assertEquals('png', $bar->getParams()['fm']);
+        $this->assertEquals(120, $bar->getParams()['w']);
+
+        $this->assertEquals('jpg', $foo->getParams()['fm']);
+        $this->assertEquals(45, $foo->getParams()['w']);
+    }
 }

--- a/tests/Unit/FluentUrlTest.php
+++ b/tests/Unit/FluentUrlTest.php
@@ -2,38 +2,43 @@
 
 namespace AmpedWeb\GlideUrl\Tests\Unit;
 
+use AmpedWeb\GlideUrl\Interfaces\Border;
+use AmpedWeb\GlideUrl\Interfaces\Filter;
+use AmpedWeb\GlideUrl\Interfaces\Fit;
+use AmpedWeb\GlideUrl\Interfaces\Rotate;
 use AmpedWeb\GlideUrl\Tests\TestCase;
 
 class FluentUrlTest extends TestCase
 {
 
-    public function testPresetsMethod() {
-
-        $this->glideUrl->preset('small',['w'=>100]);
+    public function testPresetsMethod()
+    {
+        $this->glideUrl->preset('small', ['w' => 100]);
 
         $this->assertEquals('small', $this->glideUrl->getParams()['p']);
         $this->assertEquals(100, $this->glideUrl->getParams()['w']);
     }
 
-    public function testPresetsMethodWitjArrau() {
+    public function testPresetsMethodWitjArrau()
+    {
+        $presetArray = ['small', 'large'];
 
-        $presetArray = ['small','large'];
+        $this->glideUrl->preset($presetArray, ['w' => 100]);
 
-        $this->glideUrl->preset($presetArray,['w'=>100]);
-
-        $this->assertEquals('small,large',$this->glideUrl->getParams()['p']);
+        $this->assertEquals('small,large', $this->glideUrl->getParams()['p']);
 
         $this->assertEquals(100, $this->glideUrl->getParams()['w']);
     }
 
-    public function testBuildMethodIsFluent() {
-        $this->assertEquals($this->glideUrl,$this->glideUrl->build());
+    public function testBuildMethodIsFluent()
+    {
+        $this->assertEquals($this->glideUrl, $this->glideUrl->build());
         $this->assertEmpty($this->glideUrl->getParams());
     }
 
-    public function testCustomMethod() {
-
-        $customArray = ['w'=>40,'h'=>40,'fm'=>'webp'];
+    public function testCustomMethod()
+    {
+        $customArray = ['w' => 40, 'h' => 40, 'fm' => 'webp'];
         $expectedPath = '/img/foo.png';
 
         $customUrl = $this->glideUrl->custom($customArray);
@@ -42,24 +47,22 @@ class FluentUrlTest extends TestCase
 
         //Parse the URL query string into an array
         $parsedUrl = parse_url($customUrl);
-        parse_str($parsedUrl['query'],$queryParams);
+        parse_str($parsedUrl['query'], $queryParams);
 
         //Check query params match
         foreach ($customArray as $paramKey => $paramVal) {
-            $this->assertEquals($paramVal,$queryParams[$paramKey]);
+            $this->assertEquals($paramVal, $queryParams[$paramKey]);
         }
 
         //Check base path matches
-        $this->assertEquals($parsedUrl['path'],$expectedPath);
-
+        $this->assertEquals($parsedUrl['path'], $expectedPath);
     }
 
-    public function testUrlMethod() {
-
+    public function testUrlMethod()
+    {
         $url = $this->glideUrl->width(40)->height(50)->fit('crop')->webp()->url();
 
         $this->assertIsString($url);
-
     }
 
     public function testSetAndGetPath()
@@ -75,26 +78,24 @@ class FluentUrlTest extends TestCase
     }
 
 
-    public function testPathClosure() {
-
-        $this->glideUrl->setPathClosure(function($path) {
-            return 'bar'.$path;
+    public function testPathClosure()
+    {
+        $this->glideUrl->setPathClosure(function ($path) {
+            return 'bar' . $path;
         });
 
-        $this->assertEquals('barfoo.png',$this->glideUrl->getPath());
-
+        $this->assertEquals('barfoo.png', $this->glideUrl->getPath());
     }
 
-    public function testUrlClosure() {
-
-        $this->glideUrl->setUrlClosure(function($url) {
-            return 'bar'.$url;
+    public function testUrlClosure()
+    {
+        $this->glideUrl->setUrlClosure(function ($url) {
+            return 'bar' . $url;
         });
 
         $urlParsed = parse_url($this->glideUrl->url());
 
-        $this->assertNotFalse(strpos($urlParsed['path'],'bar'));
-
+        $this->assertNotFalse(strpos($urlParsed['path'], 'bar'));
     }
 
     public function testStringCast()
@@ -102,5 +103,128 @@ class FluentUrlTest extends TestCase
         $this->glideUrl->setPath('foo');
 
         $this->assertEquals('/img/foo?s=7af3bd98ffed0ef0d402c2d33bd88b43', (string)$this->glideUrl);
+    }
+
+    public function testSubsequentOptionsOverrideExistingOnes()
+    {
+        // Source Filename
+        $foo = $this->glideUrl->setPath('foo');
+        $this->assertStringContainsString('/img/foo', $foo->url());
+
+        $foo->setPath('bar');
+        $this->assertStringContainsString('/img/bar', $foo);
+
+        // Fit
+        $foo->fit(Fit::CONTAIN);
+        $this->assertEquals(Fit::CONTAIN, $foo->getParams()['fit']);
+
+        $foo->fit(Fit::CROP);
+        $this->assertEquals(Fit::CROP, $foo->getParams()['fit']);
+
+        // Encoding
+        $foo->jpeg(50);
+        $this->assertEquals('jpg', $foo->getParams()['fm']);
+        $this->assertEquals(50, $foo->getParams()['q']);
+
+        $foo->png();
+        $this->assertEquals('png', $foo->getParams()['fm']);
+        $this->assertArrayNotHasKey('q', $foo->getParams());
+
+        // Adjustments
+        $foo->bri(1)->con(2)->gam(0.3)->sharp(4);
+        $this->assertEquals(1, $foo->getParams()['bri']);
+        $this->assertEquals(2, $foo->getParams()['con']);
+        $this->assertEquals(0.3, $foo->getParams()['gam']);
+        $this->assertEquals(4, $foo->getParams()['sharp']);
+
+        $foo->bri(4)->con(3)->gam(0.2)->sharp(1);
+        $this->assertEquals(4, $foo->getParams()['bri']);
+        $this->assertEquals(3, $foo->getParams()['con']);
+        $this->assertEquals(0.2, $foo->getParams()['gam']);
+        $this->assertEquals(1, $foo->getParams()['sharp']);
+
+        $foo->bri(2)->con(4)->gam(0.6)->sharp(8)->bri(3)->con(6)->gam(0.9);
+        $this->assertEquals(3, $foo->getParams()['bri']);
+        $this->assertEquals(6, $foo->getParams()['con']);
+        $this->assertEquals(0.9, $foo->getParams()['gam']);
+        $this->assertEquals(8, $foo->getParams()['sharp']);
+
+        // Background
+        $foo->bg('abc')->bg('def');
+        $this->assertEquals('DEF', $foo->getParams()['bg']);
+
+        // Border
+        $foo->border(3, 'abc')->border(8, 'f00');
+        $this->assertEquals(
+            sprintf('%s,%s,%s', 8, 'F00', Border::OVERLAY),
+            $this->glideUrl->getParams()['border']
+        );
+
+        // Crop
+        $foo->crop(50, 50)->crop(25,75);
+        $this->assertEquals(25, $foo->getParams()['w']);
+        $this->assertEquals(75, $foo->getParams()['h']);
+        $this->assertEquals(Fit::CROP, $foo->getParams()['fit']);
+
+        $foo->crop(12, 34)->fit(Fit::CONTAIN)->width(150)->height();
+        $this->assertEquals(150, $foo->getParams()['w']);
+        $this->assertEquals(Fit::CONTAIN, $foo->getParams()['fit']);
+        $this->assertArrayNotHasKey('h', $foo->getParams());
+
+        // Width/Height/Size
+        $foo->width(25)->height(25)->width();
+        $this->assertEquals(25, $foo->getParams()['h']);
+        $this->assertArrayNotHasKey('w', $foo->getParams());
+
+        $foo->width(100)->height(200)->size(45);
+        $this->assertEquals(45, $foo->getParams()['w']);
+        $this->assertArrayNotHasKey('h', $foo->getParams());
+
+
+        // Effects
+        // Blur
+        $foo->blur(25)->blur();
+        $this->assertEquals(0, $foo->getParams()['blur']);
+
+        // Pixel
+        $foo->pixel(25)->pixel();
+        $this->assertEquals(0, $foo->getParams()['pixel']);
+
+        // Filt
+        $foo->filt(Filter::GREYSCALE)->filter(Filter::SEPIA);
+        $this->assertEquals(Filter::SEPIA, $foo->getParams()['filt']);
+
+        // Orientation
+        $foo->orientation(Rotate::AUTO)->orientation(Rotate::R270);
+        $this->assertEquals(Rotate::R270, $foo->getParams()['or']);
+
+        // DPR
+        $foo->dpr(5)->dpr(1);
+        $this->assertEquals(1, $foo->getParams()['dpr']);
+
+        // Watermarks
+        $foo->mark('bar')->mark('baz');
+        $this->assertEquals('baz', $foo->getParams()['mark']);
+
+        $foo->markX(5)->markX(2);
+        $this->assertEquals(2, $foo->getParams()['markx']);
+
+        $foo->markY(8)->markY(4);
+        $this->assertEquals(4, $foo->getParams()['marky']);
+
+        $foo->markAlpha(30)->markAlpha(75);
+        $this->assertEquals(75, $foo->getParams()['markalpha']);
+
+        $foo->markFit(Fit::CROP)->markFit(Fit::CONTAIN);
+        $this->assertEquals(Fit::CONTAIN, $foo->getParams()['markfit']);
+
+        $foo->markPad('3w')->markPad('4h');
+        $this->assertEquals('4h', $foo->getParams()['markpad']);
+
+        $foo->markWidth(30)->markWidth(60);
+        $this->assertEquals(60, $foo->getParams()['markw']);
+
+        $foo->markHeight(20)->markHeight(50);
+        $this->assertEquals(50, $foo->getParams()['markh']);
     }
 }

--- a/tests/Unit/OrientationTest.php
+++ b/tests/Unit/OrientationTest.php
@@ -54,4 +54,10 @@ class OrientationTest extends TestCase
         $this->glideUrl->orientation(HasOrientation::$ORIENTATION_270);
         $this->assertEquals('270', $this->glideUrl->getParams()['or']);
     }
+
+    public function testOrientationCanBeRemoved()
+    {
+        $this->glideUrl->orientation(HasOrientation::$ORIENTATION_270)->orientation();
+        $this->assertArrayNotHasKey('or', $this->glideUrl->getParams());
+    }
 }

--- a/tests/Unit/SizeTest.php
+++ b/tests/Unit/SizeTest.php
@@ -57,6 +57,9 @@ class SizeTest extends TestCase
     {
         $this->glideUrl->width(50);
         $this->assertEquals(50, $this->glideUrl->getParams()['w']);
+
+        $this->glideUrl->width();
+        $this->assertArrayNotHasKey('w', $this->glideUrl->getParams());
     }
 
     public function testWidthIsFluent()
@@ -68,6 +71,9 @@ class SizeTest extends TestCase
     {
         $this->glideUrl->height(100);
         $this->assertEquals(100, $this->glideUrl->getParams()['h']);
+
+        $this->glideUrl->height();
+        $this->assertArrayNotHasKey('h', $this->glideUrl->getParams());
     }
 
     public function testHeightIsFluent()
@@ -80,6 +86,14 @@ class SizeTest extends TestCase
         $this->glideUrl->size(320,240);
         $this->assertEquals(320, $this->glideUrl->getParams()['w']);
         $this->assertEquals(240, $this->glideUrl->getParams()['h']);
+
+        $this->glideUrl->size(null, 25);
+        $this->assertArrayNotHasKey('w', $this->glideUrl->getParams());
+        $this->assertEquals(25, $this->glideUrl->getParams()['h']);
+
+        $this->glideUrl->size(25);
+        $this->assertArrayNotHasKey('h', $this->glideUrl->getParams());
+        $this->assertEquals(25, $this->glideUrl->getParams()['w']);
     }
 
     public function testSizeIsFluent()

--- a/tests/Unit/WatermarksTest.php
+++ b/tests/Unit/WatermarksTest.php
@@ -5,6 +5,7 @@ namespace AmpedWeb\GlideUrl\Tests\Unit;
 
 use AmpedWeb\GlideUrl\Exceptions\InvalidFitException;
 use AmpedWeb\GlideUrl\Exceptions\InvalidMarkPositionException;
+use AmpedWeb\GlideUrl\Interfaces\Fit;
 use AmpedWeb\GlideUrl\Tests\TestCase;
 
 class WatermarksTest extends TestCase
@@ -151,5 +152,41 @@ class WatermarksTest extends TestCase
 
         $this->glideUrl->markAlpha(999);
         $this->assertEquals(100, $this->glideUrl->getParams()['markalpha']);
+    }
+
+    public function testMarkCanBeCleared()
+    {
+        $this->glideUrl->mark('foo')->mark();
+        $this->assertArrayNotHasKey('mark', $this->glideUrl->getParams());
+    }
+
+    public function testMarkWidthCanBeCleared()
+    {
+        $this->glideUrl->markWidth(32)->markWidth();
+        $this->assertArrayNotHasKey('markw', $this->glideUrl->getParams());
+    }
+
+    public function testMarkHeightCanBeCleared()
+    {
+        $this->glideUrl->markHeight(54)->markHeight();
+        $this->assertArrayNotHasKey('markh', $this->glideUrl->getParams());
+    }
+
+    public function testMarkXCanBeCleared()
+    {
+        $this->glideUrl->markX(43)->markX();
+        $this->assertArrayNotHasKey('markx', $this->glideUrl->getParams());
+    }
+
+    public function testMarkYCanBeCleared()
+    {
+        $this->glideUrl->markY(89)->markY();
+        $this->assertArrayNotHasKey('marky', $this->glideUrl->getParams());
+    }
+
+    public function testMarkPadCanBeCleared()
+    {
+        $this->glideUrl->markPad('5w')->markPad();
+        $this->assertArrayNotHasKey('markpad', $this->glideUrl->getParams());
     }
 }


### PR DESCRIPTION
This pull request adds the following:

- Avif encoding support:
```php
$builder->avif();
$builder->avif(45); // with a quality level
```

- easy cloning of a FluentUrlBuilder instance at any point.  This also allows for many of the modifier functions to be "cancelled" after the event.  For example:

```php
$squareJpeg = $builder->setPath('my_image')->width(320)->height(320)->fit('crop')->jpeg();

// But I want it wider
$rectangularJpeg = $squareJpeg->clone()->width(640);

// At its original height
$tallJpeg = $rectangularImage->clone()->height();

// And now in WebP
$webp = $tallJpeg->clone()->webp();

// Actually, no.  As a banner in avif
$avif = $webp->clone()->width(1920)->height(800)->fit('max')->avif();
```